### PR TITLE
Support for running script as root

### DIFF
--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -267,7 +267,7 @@ class EmailSender:
 ######################## FUNCTION DEFINITIONS ################################
 
 def get_sid():
-    SID = subprocess.check_output('echo $SAPSYSTEMNAME',  shell=True)
+    SID = subprocess.check_output('echo $SAPSYSTEMNAME',  shell=True).strip("\n")
     return SID
 
 def is_integer(s):
@@ -1050,8 +1050,8 @@ def main():
                 os._exit(1)
 
     ############ GET SID ##########
-    SID = subprocess.check_output('whoami', shell=True).replace('\n','').replace('adm','').upper() 
-    SID = get_sid().strip("\n")
+    
+    SID = get_sid()
 
     #####################  PRIMARY INPUT ARGUMENTS   ####################     
     if '-h' in sys.argv or '--help' in sys.argv:

--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -267,7 +267,7 @@ class EmailSender:
 ######################## FUNCTION DEFINITIONS ################################
 
 def get_sid():
-    SID = subprocess.check_output('echo $SAPSYSTEMNAME',  shell=True).strip("\n")
+    SID = subprocess.check_output('echo $SAPSYSTEMNAME',  shell=True).strip("\n").upper()
     return SID
 
 def is_integer(s):
@@ -649,7 +649,7 @@ def zipBackupLogs(zipBackupLogsSizeLimit, zipBackupPath, zipLinks, zipOut, zipKe
 def cdalias(alias):   # alias e.g. cdtrace, cdhdb, ...
     whoami = subprocess.check_output('whoami', shell=True).replace('\n','')
     if whoami.lower() == 'root':
-        sidadm = get_sid().strip("\n").lower()+'adm'
+        sidadm = get_sid().lower()+'adm'
         cmd1 = 'su - '+sidadm+' /bin/bash -l -c \'alias '+alias+'\''
         command_run = subprocess.check_output(cmd1, shell=True)
     else:

--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -647,25 +647,22 @@ def zipBackupLogs(zipBackupLogsSizeLimit, zipBackupPath, zipLinks, zipOut, zipKe
     return nZipped
     
 def cdalias(alias):   # alias e.g. cdtrace, cdhdb, ...
+    su_cmd = ''
     whoami = subprocess.check_output('whoami', shell=True).replace('\n','')
     if whoami.lower() == 'root':
         sidadm = get_sid().lower()+'adm'
-        cmd1 = 'su - '+sidadm+' /bin/bash -l -c \'alias '+alias+'\''
-        command_run = subprocess.check_output(cmd1, shell=True)
-    else:
-        command_run = subprocess.check_output(['/bin/bash', '-l', '-c', "alias "+alias])
+        su_cmd = 'su - '+sidadm+' '
+    alias_cmd = su_cmd+'/bin/bash -l -c \'alias '+alias+'\''
+    command_run = subprocess.check_output(alias_cmd, shell=True)
     #pieces = command_run.strip("\n").strip("alias "+alias+"=").strip("'").strip("cd ").split("/")
     pieces = re.sub(r'.*cd ','',command_run).strip("\n").strip("'").split("/")    #to remove ANSI escape codes (only needed in few systems)
     path = ''
     for piece in pieces:
         if piece and piece[0] == '$':
-            if whoami.lower() == 'root':
-                cmd2 ='su - '+sidadm+' /bin/bash -l -c'+"\' echo "+piece+'\''
-                piece = (subprocess.check_output(cmd2, shell=True)).strip("\n")
-            else:
-                piece = (subprocess.check_output(['/bin/bash', '-l', '-c', "echo "+piece])).strip("\n")
+            piece_cmd = su_cmd+'/bin/bash -l -c'+" \' echo "+piece+'\''
+            piece = (subprocess.check_output(piece_cmd, shell=True)).strip("\n")
         path = path + '/' + piece + '/' 
-    return path  
+    return path
 
 def reclaim_logsegments(maxFreeLogsegments, sqlman, logman):
     nTotFreeLogsegmentsBefore = int(subprocess.check_output(sqlman.hdbsql_jAQaxU + " \"SELECT COUNT(*) FROM SYS.M_LOG_SEGMENTS WHERE STATE = 'Free'\"", shell=True, stderr=subprocess.STDOUT).strip(' '))

--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -1047,7 +1047,6 @@ def main():
                 os._exit(1)
 
     ############ GET SID ##########
-    
     SID = get_sid()
 
     #####################  PRIMARY INPUT ARGUMENTS   ####################     


### PR DESCRIPTION
Hello,

in order to increase the security for scheduled runs via `cron` we would like to have user key stored under the `hdbuserstore` of `root` user rather than in `hdbuserstore` of `<sid>adm` user (the logic is that fewer people are having access to `root` user compared to `<sid>adm` user and `root` user can anytime switch to `<sid>adm` user anyway).

We tested the code and when we source the environment variables via `source /usr/sap/<SID>/home/.sapenv.sh` then we are able to run the script - the only problem is usage of aliases from inside the script.

We developed and tested the enhancement of the code to detect whether executed from `root` and in such case to read the aliases from `<sid>adm` shell instead of "existing user" shell.

Note: we are aware of requirement to run on Python 2.7.x and we are making sure we are compliant here.

Can you please review the code enhancement and consider accepting the contribution?

Thank you.