### PR TITLE
Allow FQDN in hdbuserstore key

### DIFF
--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -1777,7 +1777,7 @@ def main():
                 print "ERROR, the key ", dbuserkey, " is not maintained in hdbuserstore."
                 os._exit(1)
             ENV = key_environment.split('\n')[1].replace('  ENV : ','').replace(';',',').split(',')
-            key_hosts = [env.split(':')[0] for env in ENV] 
+            key_hosts = [env.split(':')[0].split('.')[0] for env in ENV] 
             if not local_host in key_hosts:
                 print "ERROR, local host, ", local_host, ", should be one of the hosts specified for the key, ", dbuserkey, " (in case of virtual, please use -vlh, see --help for more info)"
                 os._exit(1)


### PR DESCRIPTION
At the moment is is not possible to have FQDN in hdbuserstore key and most likely you have to use the `-vlh` flag instead:

Execution:

```
hanacleaner.py -ff hanacleaner.cfg

ERROR, local host,  my_host_name , should be one of the hosts specified for the key,  HANACLEANERKEY  (in case of virtual, please use -vlh)
```

hdbuserkey:
```
hdbuserstore list HANACLEANERKEY
KEY HANACLEANERKEY
  ENV : my_host_name.example.com:30013
  USER: HANACLEANER
```
Whit this fix it will be possible to use KEYs with/without FQDN. 