### PR TITLE
Typo in printEmailSender

### DIFF
--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -331,7 +331,7 @@ class EmailSender:
             print("Mail Server: ", self.mailServer)
         else:
             print("Configured mail server will be used.")
-        print("Reciever Emails: ", self.recieverEmails)
+        print("Reciever Emails: ", self.receiverEmails)
 
 ######################## FUNCTION DEFINITIONS ################################
 


### PR DESCRIPTION
there was a typo in the receiverEmails print statement in line 334 ( ie instead of ei)