### PR TITLE
bugfix determination of the first backup to retain

### DIFF
--- a/hanacleaner.py
+++ b/hanacleaner.py
@@ -453,7 +453,7 @@ def get_key_info(dbuserkey, local_host, logman):
 
 def sql_for_backup_id_for_min_retained_days(minRetainedDays):
     oldestDayForKeepingBackup = datetime.now() + timedelta(days = -int(minRetainedDays))
-    return "SELECT TOP 1 ENTRY_ID, SYS_START_TIME from sys.m_backup_catalog where (ENTRY_TYPE_NAME = 'complete data backup' or ENTRY_TYPE_NAME = 'data snapshot') and STATE_NAME = 'successful' and SYS_START_TIME < '" + oldestDayForKeepingBackup.strftime('%Y-%m-%d')+" 00:00:00' order by SYS_START_TIME desc"
+    return "SELECT TOP 1 ENTRY_ID, SYS_START_TIME from sys.m_backup_catalog where (ENTRY_TYPE_NAME = 'complete data backup' or ENTRY_TYPE_NAME = 'data snapshot') and STATE_NAME = 'successful' and SYS_START_TIME >= '" + oldestDayForKeepingBackup.strftime('%Y-%m-%d')+" 00:00:00' order by SYS_START_TIME asc"
 
 
 def sql_for_backup_id_for_min_retained_backups(minRetainedBackups):


### PR DESCRIPTION
today = 2022-09-12. bd = 2. old code selects the last backup prior 2022-09-10. the selected backup is 2022-02-09 23:59:59 or older. the result is that the last backup prior 2022-09-10 will not be deleted. And this is wrong. Change the sql to select the first backup to retain. This results in correct deletion of all backups prio 2022-09-10.